### PR TITLE
feat: Delete machine

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -30,6 +30,12 @@ const (
 	// MicrovmPendingReason indicates the microvm is in a pending state.
 	MicrovmPendingReason = "MicrovmPending"
 
+	// MicrovmDeletingReason indicates the microvm is in a deleted state.
+	MicrovmDeletingReason = "MicrovmDeleting"
+
+	// MicrovmDeletedFailedReason indicates the microvm failed to deleted cleanly.
+	MicrovmDeleteFailedReason = "MicrovmDeleteFailed"
+
 	// MicrovmUnknownStateReason indicates that the microvm in in an unknown or unsupported state
 	// for reconciliation.
 	MicrovmUnknownStateReason = "MicrovmUnknownState"

--- a/api/v1alpha1/microvmcluster_types.go
+++ b/api/v1alpha1/microvmcluster_types.go
@@ -8,12 +8,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	// ClusterFinalizer allows ReconcileMicrovmCluster to clean up esources associated with MicrovmCluster before
-	// removing it from the apiserver.
-	ClusterFinalizer = "microvmcluster.infrastructure.cluster.x-k8s.io"
-)
-
 // MicrovmClusterSpec defines the desired state of MicrovmCluster.
 type MicrovmClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -356,3 +356,7 @@ func hasMachineFinalizer(machine *infrav1.MicrovmMachine) bool {
 
 	return false
 }
+
+func assertMachineNotReady(g *WithT, machine *infrav1.MicrovmMachine) {
+	g.Expect(machine.Status.Ready).To(BeFalse())
+}

--- a/controllers/microvmcluster_controller.go
+++ b/controllers/microvmcluster_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -120,9 +119,7 @@ func (r *MicrovmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *MicrovmClusterReconciler) reconcileDelete(_ context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	clusterScope.Info("Reconciling MicrovmCluster delete")
 
-	// TODO: do any required deletion
-
-	controllerutil.RemoveFinalizer(clusterScope.MvmCluster, infrav1.ClusterFinalizer)
+	// We currently do not do any Cluster creation so there is nothing to delete.
 
 	return reconcile.Result{}, nil
 }
@@ -133,8 +130,6 @@ func (r *MicrovmClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	if clusterScope.Cluster.Spec.ControlPlaneEndpoint.IsZero() && clusterScope.MvmCluster.Spec.ControlPlaneEndpoint.IsZero() {
 		return reconcile.Result{}, errControlplaneEndpointRequired
 	}
-
-	controllerutil.AddFinalizer(clusterScope.MvmCluster, infrav1.ClusterFinalizer)
 
 	clusterScope.MvmCluster.Status.Ready = true
 

--- a/controllers/microvmcluster_controller_test.go
+++ b/controllers/microvmcluster_controller_test.go
@@ -42,8 +42,6 @@ func TestClusterReconciliationNoEndpoint(t *testing.T) {
 
 	c := conditions.Get(reconciled, infrav1.LoadBalancerAvailableCondition)
 	g.Expect(c).To(BeNil())
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(0))
 }
 
 func TestClusterReconciliationWithClusterEndpoint(t *testing.T) {
@@ -89,8 +87,6 @@ func TestClusterReconciliationWithClusterEndpoint(t *testing.T) {
 	c = conditions.Get(reconciled, clusterv1.ReadyCondition)
 	g.Expect(c).ToNot(BeNil())
 	g.Expect(c.Status).To(Equal(corev1.ConditionTrue))
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(1))
 }
 
 func TestClusterReconciliationWithMvmClusterEndpoint(t *testing.T) {
@@ -136,8 +132,6 @@ func TestClusterReconciliationWithMvmClusterEndpoint(t *testing.T) {
 	c = conditions.Get(reconciled, clusterv1.ReadyCondition)
 	g.Expect(c).ToNot(BeNil())
 	g.Expect(c.Status).To(Equal(corev1.ConditionTrue))
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(1))
 }
 
 func TestClusterReconciliationWithClusterEndpointAPIServerNotReady(t *testing.T) {
@@ -177,8 +171,6 @@ func TestClusterReconciliationWithClusterEndpointAPIServerNotReady(t *testing.T)
 	c = conditions.Get(reconciled, clusterv1.ReadyCondition)
 	g.Expect(c).ToNot(BeNil())
 	g.Expect(c.Status).To(Equal(corev1.ConditionFalse))
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(1))
 }
 
 func TestClusterReconciliationMicrovmAlreadyDeleted(t *testing.T) {
@@ -221,8 +213,6 @@ func TestClusterReconciliationNotOwner(t *testing.T) {
 
 	c := conditions.Get(reconciled, infrav1.LoadBalancerAvailableCondition)
 	g.Expect(c).To(BeNil())
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(0))
 }
 
 func TestClusterReconciliationWhenPaused(t *testing.T) {
@@ -251,8 +241,6 @@ func TestClusterReconciliationWhenPaused(t *testing.T) {
 
 	c := conditions.Get(reconciled, infrav1.LoadBalancerAvailableCondition)
 	g.Expect(c).To(BeNil())
-
-	g.Expect(reconciled.Finalizers).To(HaveLen(0))
 }
 
 func TestClusterReconciliationDelete(t *testing.T) {
@@ -276,7 +264,6 @@ func TestClusterReconciliationDelete(t *testing.T) {
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 	// TODO: when we move to envtest this should return an NotFound error. #30
-	reconciled, err := getMicrovmCluster(context.TODO(), client, testClusterName, testClusterNamespace)
+	_, err = getMicrovmCluster(context.TODO(), client, testClusterName, testClusterNamespace)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(reconciled.Finalizers).To(HaveLen(0))
 }

--- a/internal/services/microvm/service.go
+++ b/internal/services/microvm/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/cluster-api-provider-microvm/internal/defaults"
 	"github.com/weaveworks/cluster-api-provider-microvm/internal/scope"
 	"github.com/yitsushi/macpot"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"k8s.io/utils/pointer"
 
 	flintlockv1 "github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
@@ -88,4 +89,15 @@ func (s *Service) Get(ctx context.Context) (*flintlocktypes.MicroVM, error) {
 	}
 
 	return resp.Microvm, nil
+}
+
+func (s *Service) Delete(ctx context.Context) (*emptypb.Empty, error) {
+	s.scope.V(defaults.LogLevelDebug).Info("Deleting microvm for machine", "machine-name", s.scope.Name(), "cluster-name", s.scope.ClusterName())
+
+	input := &flintlockv1.DeleteMicroVMRequest{
+		Id:        s.scope.Name(),
+		Namespace: s.scope.Namespace(),
+	}
+
+	return s.client.DeleteMicroVM(ctx, input)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements MicroVMMachine deletion reconcile.
Calls the flintlock API.

LMK if I have missed any CAPI-type things, was
mostly guessing.

Also removes finalizers from the Cluster controller
as we do not do any supporting infrastructure
creation there. We can add this back later if it changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/weaveworks/cluster-api-provider-microvm/issues/13

**Special notes for your reviewer**:

Successfully ran a manual create+delete on my local machine.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests