### PR TITLE
feat: added vendor-data and ssh key support

### DIFF
--- a/api/v1alpha1/microvmcluster_types.go
+++ b/api/v1alpha1/microvmcluster_types.go
@@ -17,6 +17,12 @@ type MicrovmClusterSpec struct {
 	//
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// SSHPublicKey is an SSH public key that will be used with the default user. If specified
+	// this will apply to all machine created unless you specify a different key at the
+	// machine level.
+	// +optional
+	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 }
 
 // MicrovmClusterStatus defines the observed state of MicrovmCluster.

--- a/api/v1alpha1/microvmmachine_types.go
+++ b/api/v1alpha1/microvmmachine_types.go
@@ -19,6 +19,12 @@ const (
 type MicrovmMachineSpec struct {
 	MicrovmSpec `json:",inline"`
 
+	// SSHPublicKey is an SSH public key that will be used with the default user on this
+	// machine. If specified it will take precedence over any SSH key specified at
+	// the cluster level.
+	// +optional
+	SSHPublicKey string `json:"sshPublicKey,omitempty"`
+
 	// ProviderID is the unique identifier as specified by the cloud provider.
 	ProviderID *string `json:"providerID,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
@@ -69,6 +69,11 @@ spec:
                 - host
                 - port
                 type: object
+              sshPublicKey:
+                description: SSHPublicKey is an SSH public key that will be used with
+                  the default user. If specified this will apply to all machine created
+                  unless you specify a different key at the machine level.
+                type: string
             type: object
           status:
             description: MicrovmClusterStatus defines the observed state of MicrovmCluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
@@ -139,6 +139,11 @@ spec:
                 - id
                 - image
                 type: object
+              sshPublicKey:
+                description: SSHPublicKey is an SSH public key that will be used with
+                  the default user on this machine. If specified it will take precedence
+                  over any SSH key specified at the cluster level.
+                type: string
               vcpu:
                 description: VCPU specifies how many vcpu's the microvm will be allocated.
                 format: int64

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
@@ -176,6 +176,12 @@ spec:
                         - id
                         - image
                         type: object
+                      sshPublicKey:
+                        description: SSHPublicKey is an SSH public key that will be
+                          used with the default user on this machine. If specified
+                          it will take precedence over any SSH key specified at the
+                          cluster level.
+                        type: string
                       vcpu:
                         description: VCPU specifies how many vcpu's the microvm will
                           be allocated.

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,11 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576
-	github.com/weaveworks/flintlock/client v0.0.0-20211213114330-12eb53621738
+	github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b
 	github.com/yitsushi/macpot v1.0.2
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.4
 	k8s.io/apimachinery v0.22.4
 	k8s.io/client-go v0.22.4
@@ -70,7 +71,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211021150943-2b146023228c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.22.2 // indirect
 	k8s.io/cluster-bootstrap v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576 h1:f5QFSzuYSgpzgKkrS/sXTwr+ZnPzP9oR40na9nzgotg=
 github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576/go.mod h1:RFgQ7RSa7zGNxxR+dS6NRDCQ/IAN23WCfXg4+L6fclI=
-github.com/weaveworks/flintlock/client v0.0.0-20211213114330-12eb53621738 h1:UyKUaJYf/dN8zcq7OWy15ISSjOjqwOyXe4acWOt7NdM=
-github.com/weaveworks/flintlock/client v0.0.0-20211213114330-12eb53621738/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
+github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b h1:CerxjKG6oiUPfEDlJA8SwzR/5cCybzg8sQJ/999KXJ0=
+github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/internal/scope/machine.go
+++ b/internal/scope/machine.go
@@ -199,3 +199,17 @@ func (m *MachineScope) SetNotReady(reason string, severity clusterv1.ConditionSe
 	conditions.MarkFalse(m.MvmMachine, infrav1.MicrovmReadyCondition, reason, severity, message, messageArgs...)
 	m.MvmMachine.Status.Ready = false
 }
+
+// GetSSHPublicKey will return the SSH public key for this machine. It will take into account
+// precedence rules. If there is no key then an empty string will be returned.
+func (m *MachineScope) GetSSHPublicKey() string {
+	if m.MvmMachine.Spec.SSHPublicKey != "" {
+		return m.MvmMachine.Spec.SSHPublicKey
+	}
+
+	if m.MvmCluster.Spec.SSHPublicKey != "" {
+		return m.MvmCluster.Spec.SSHPublicKey
+	}
+
+	return ""
+}

--- a/internal/services/microvm/convert.go
+++ b/internal/services/microvm/convert.go
@@ -4,12 +4,7 @@
 package microvm
 
 import (
-	"encoding/base64"
-	"fmt"
-
 	flintlocktypes "github.com/weaveworks/flintlock/api/types"
-	flcloudinit "github.com/weaveworks/flintlock/client/cloudinit"
-	"gopkg.in/yaml.v3"
 
 	"github.com/weaveworks/cluster-api-provider-microvm/api/v1alpha1"
 	"github.com/weaveworks/cluster-api-provider-microvm/internal/scope"
@@ -17,7 +12,7 @@ import (
 
 const platformLiquidMetal = "liquid_metal"
 
-func convertToFlintlockAPI(machineScope *scope.MachineScope) (*flintlocktypes.MicroVMSpec, error) {
+func convertToFlintlockAPI(machineScope *scope.MachineScope) *flintlocktypes.MicroVMSpec {
 	mvmSpec := machineScope.MvmMachine.Spec
 
 	apiVM := &flintlocktypes.MicroVMSpec{
@@ -89,19 +84,5 @@ func convertToFlintlockAPI(machineScope *scope.MachineScope) (*flintlocktypes.Mi
 		apiVM.Interfaces = append(apiVM.Interfaces, apiIface)
 	}
 
-	userMetadata := flcloudinit.Metadata{
-		InstanceID:    fmt.Sprintf("%s/%s", machineScope.Namespace(), machineScope.Name()),
-		LocalHostname: machineScope.Name(),
-		Platform:      platformLiquidMetal,
-		ClusterName:   machineScope.ClusterName(),
-	}
-
-	userMeta, err := yaml.Marshal(userMetadata)
-	if err != nil {
-		return apiVM, fmt.Errorf("unable to marshal metadata: %w", err)
-	}
-
-	apiVM.Metadata["meta-data"] = base64.StdEncoding.EncodeToString(userMeta)
-
-	return apiVM, nil
+	return apiVM
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed the API definitions of the MicrovmCluster/Machine to allow
setting of a public SSH key that will be attached to the **default**
user during cloud-init. This additional data is specified via
vendor-data so that we leave the user-data (from the bootstrap provider) unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #43 
Fixes #46 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests