### PR TITLE
fix: do not default mount point for volumes

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -72,15 +72,15 @@ type Volume struct {
 	// ID is a unique identifier for this volume.
 	// +kubebuilder:validation:Required
 	ID string `json:"id"`
-
 	// Image is the container image to use for the volume.
 	// +kubebuilder:validation:Required
 	Image string `json:"image"`
 	// ReadOnly specifies that the volume is to be mounted readonly.
+	// +kubebuilder:default:=false
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty"`
 	// MountPoint is the mount point of the volume in the machine.
-	// +kubebuilder:default:=/
+	// +kubebuilder:validation:Required
 	MountPoint string `json:"mountPoint,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
@@ -127,11 +127,11 @@ spec:
                     description: Image is the container image to use for the volume.
                     type: string
                   mountPoint:
-                    default: /
                     description: MountPoint is the mount point of the volume in the
                       machine.
                     type: string
                   readOnly:
+                    default: false
                     description: ReadOnly specifies that the volume is to be mounted
                       readonly.
                     type: boolean
@@ -157,11 +157,11 @@ spec:
                       description: Image is the container image to use for the volume.
                       type: string
                     mountPoint:
-                      default: /
                       description: MountPoint is the mount point of the volume in
                         the machine.
                       type: string
                     readOnly:
+                      default: false
                       description: ReadOnly specifies that the volume is to be mounted
                         readonly.
                       type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
@@ -164,11 +164,11 @@ spec:
                               volume.
                             type: string
                           mountPoint:
-                            default: /
                             description: MountPoint is the mount point of the volume
                               in the machine.
                             type: string
                           readOnly:
+                            default: false
                             description: ReadOnly specifies that the volume is to
                               be mounted readonly.
                             type: boolean
@@ -197,11 +197,11 @@ spec:
                                 the volume.
                               type: string
                             mountPoint:
-                              default: /
                               description: MountPoint is the mount point of the volume
                                 in the machine.
                               type: string
                             readOnly:
+                              default: false
                               description: ReadOnly specifies that the volume is to
                                 be mounted readonly.
                               type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:

Taken of the kubebuilder default for the mount point of volumes,
Previously it defaulted to `/` and so if there was more than 1 volume
specified without mount points set there would be collision of mount
points. It has been changed to a required field without a default to
force users to specify it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #47 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests