### PR TITLE
fix: set workflow env in correct location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,10 @@ on:
     tags:
     - "v*.*.*"
 
+env:
+  TAG: ${{ github.ref_name }}
+
 jobs:
-  env:
-    TAG: ${{ github.ref_name }}
   build:
     runs-on: ubuntu-latest
     needs: [test]


### PR DESCRIPTION
Apparently I cannot set jobs.env but can just set env? We shall see.