### PR TITLE
fix: ensure systemd-resolvd works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576
-	github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b
+	github.com/weaveworks/flintlock/client v0.0.0-20220107100311-6a2445a32861
 	github.com/yitsushi/macpot v1.0.2
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,8 @@ github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576 h1:f5QFSz
 github.com/weaveworks/flintlock/api v0.0.0-20211124154423-21a022445576/go.mod h1:RFgQ7RSa7zGNxxR+dS6NRDCQ/IAN23WCfXg4+L6fclI=
 github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b h1:CerxjKG6oiUPfEDlJA8SwzR/5cCybzg8sQJ/999KXJ0=
 github.com/weaveworks/flintlock/client v0.0.0-20211213135217-19cc344a892b/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
+github.com/weaveworks/flintlock/client v0.0.0-20220107100311-6a2445a32861 h1:UH27IkZjwbcNDJLXX83p8BQHxploHG55X6vzLlsBilg=
+github.com/weaveworks/flintlock/client v0.0.0-20220107100311-6a2445a32861/go.mod h1:1jiepUOR2kxAdoxXXyNQ0LnOeT2gOUSnWGuXh9akjDw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/internal/services/microvm/service.go
+++ b/internal/services/microvm/service.go
@@ -138,12 +138,16 @@ func (s *Service) createVendorData() (string, error) {
 		}
 	}
 
+	// TODO: remove the boot command temporary fix after image-builder #6
 	vendorUserdata := &cloudinit.UserData{
 		HostName: s.scope.MvmMachine.Name,
 		Users: []cloudinit.User{
 			defaultUser,
 		},
 		FinalMessage: "The Liquid Metal booted system is good to go after $UPTIME seconds",
+		BootCommands: []string{
+			"ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf",
+		},
 	}
 
 	data, err := yaml.Marshal(vendorUserdata)


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to an issue with systemd-resolvd in our base image we need to
include a temporary work around that uses cloud-init to fix dns.

This can be removed after this has beed fixed: https://github.com/weaveworks/image-builder/issues/6

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests