### PR TITLE
Revert "fix: add initrd to MicrovmMachines in template (#77)"

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -68,9 +68,6 @@ spec:
     spec:
       vcpu: 2
       memoryMb: 2048
-      initrd:
-        filename: initrd-generic
-        image: ${MVM_KERNEL_IMAGE}
       rootVolume:
         id: root
         image: ${MVM_ROOT_IMAGE}
@@ -114,9 +111,6 @@ spec:
     spec:
       vcpu: 2
       memoryMb: 2048
-      initrd:
-        filename: initrd-generic
-        image: ${MVM_KERNEL_IMAGE}
       rootVolume:
         id: root
         image: ${MVM_ROOT_IMAGE}


### PR DESCRIPTION
This reverts commit 4ca1990f3bb067c9354339522bca13915925e6ea.

That change originally added initrd config to the mvm templates, but this is no longer required
