### PR TITLE
feat: set provider id earlier

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -320,8 +320,17 @@ func withMissingMicrovm(fc *mock_client.FakeClient) {
 	fc.GetMicroVMReturns(&flintlockv1.GetMicroVMResponse{}, nil)
 }
 
-func withCreateMicrovmSuccess(fc *mock_client.FakeClient) {
-	fc.CreateMicroVMReturns(&flintlockv1.CreateMicroVMResponse{}, nil)
+func withCreateMicrovmSuccess(fc *mock_client.FakeClient, mvmName string) {
+	fc.CreateMicroVMReturns(&flintlockv1.CreateMicroVMResponse{
+		Microvm: &flintlocktypes.MicroVM{
+			Spec: &flintlocktypes.MicroVMSpec{
+				Id: mvmName,
+			},
+			Status: &flintlocktypes.MicroVMStatus{
+				State: flintlocktypes.MicroVMStatus_PENDING,
+			},
+		},
+	}, nil)
 }
 
 func assertConditionTrue(g *WithT, from conditions.Getter, conditionType clusterv1.ConditionType) {

--- a/controllers/microvmmachine_controller.go
+++ b/controllers/microvmmachine_controller.go
@@ -242,8 +242,6 @@ func (r *MicrovmMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		if createErr != nil {
 			return ctrl.Result{}, createErr
 		}
-
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	switch microvm.Status.State {

--- a/controllers/microvmmachine_controller.go
+++ b/controllers/microvmmachine_controller.go
@@ -236,7 +236,10 @@ func (r *MicrovmMachineReconciler) reconcileNormal(ctx context.Context, machineS
 
 	if microvm == nil {
 		machineScope.Info("creating microvm")
-		if createErr := mvmSvc.Create(ctx, providerID); createErr != nil {
+
+		var createErr error
+		microvm, createErr = mvmSvc.Create(ctx, providerID)
+		if createErr != nil {
 			return ctrl.Result{}, createErr
 		}
 

--- a/controllers/microvmmachine_controller.go
+++ b/controllers/microvmmachine_controller.go
@@ -244,6 +244,8 @@ func (r *MicrovmMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		}
 	}
 
+	machineScope.MvmMachine.Spec.ProviderID = &providerID
+
 	switch microvm.Status.State {
 	case flintlocktypes.MicroVMStatus_FAILED:
 		// TODO: we need a failure reason from flintlock: Flintlock #299
@@ -272,7 +274,6 @@ func (r *MicrovmMachineReconciler) reconcileNormal(ctx context.Context, machineS
 
 	machineScope.Info("microvm created", "providerID", providerID)
 
-	machineScope.MvmMachine.Spec.ProviderID = &providerID
 	machineScope.SetReady()
 
 	return reconcile.Result{}, nil

--- a/controllers/microvmmachine_controller_test.go
+++ b/controllers/microvmmachine_controller_test.go
@@ -254,7 +254,7 @@ func TestMachineReconcileNoVmCreateSucceeds(t *testing.T) {
 
 	fakeAPIClient := mock_client.FakeClient{}
 	withMissingMicrovm(&fakeAPIClient)
-	withCreateMicrovmSuccess(&fakeAPIClient)
+	withCreateMicrovmSuccess(&fakeAPIClient, testMachineName)
 
 	client := createFakeClient(g, apiObjects.AsRuntimeObjects())
 	result, err := reconcileMachine(client, &fakeAPIClient)
@@ -268,6 +268,12 @@ func TestMachineReconcileNoVmCreateSucceeds(t *testing.T) {
 	g.Expect(createReq.Microvm.Metadata).To(HaveLen(3))
 	expectedBootstrapData := base64.StdEncoding.EncodeToString([]byte(testbootStrapData))
 	g.Expect(createReq.Microvm.Metadata).To(HaveKeyWithValue("user-data", expectedBootstrapData))
+
+	reconciled, err := getMicrovmMachine(client, testMachineName, testClusterNamespace)
+	g.Expect(err).NotTo(HaveOccurred(), "Getting microvm machine should not fail")
+	assertConditionFalse(g, reconciled, infrav1.MicrovmReadyCondition, infrav1.MicrovmPendingReason)
+	assertMachineVMState(g, reconciled, infrav1.VMStatePending)
+	assertMachineFinalizer(g, reconciled)
 }
 
 func TestMachineReconcileNoVmCreateClusterSSHSucceeds(t *testing.T) {
@@ -281,7 +287,7 @@ func TestMachineReconcileNoVmCreateClusterSSHSucceeds(t *testing.T) {
 
 	fakeAPIClient := mock_client.FakeClient{}
 	withMissingMicrovm(&fakeAPIClient)
-	withCreateMicrovmSuccess(&fakeAPIClient)
+	withCreateMicrovmSuccess(&fakeAPIClient, testMachineName)
 
 	client := createFakeClient(g, apiObjects.AsRuntimeObjects())
 	result, err := reconcileMachine(client, &fakeAPIClient)
@@ -314,7 +320,7 @@ func TestMachineReconcileNoVmCreateClusterMachineSSHSucceeds(t *testing.T) {
 
 	fakeAPIClient := mock_client.FakeClient{}
 	withMissingMicrovm(&fakeAPIClient)
-	withCreateMicrovmSuccess(&fakeAPIClient)
+	withCreateMicrovmSuccess(&fakeAPIClient, testMachineName)
 
 	client := createFakeClient(g, apiObjects.AsRuntimeObjects())
 	result, err := reconcileMachine(client, &fakeAPIClient)
@@ -341,7 +347,7 @@ func TestMachineReconcileNoVmCreateAdditionReconcile(t *testing.T) {
 
 	fakeAPIClient := mock_client.FakeClient{}
 	withMissingMicrovm(&fakeAPIClient)
-	withCreateMicrovmSuccess(&fakeAPIClient)
+	withCreateMicrovmSuccess(&fakeAPIClient, testMachineName)
 
 	client := createFakeClient(g, apiObjects.AsRuntimeObjects())
 	result, err := reconcileMachine(client, &fakeAPIClient)


### PR DESCRIPTION
feat: set the provider ID earlier

At the old location the ID was not persisted before the state switch,
meaning that we would sometimes (in almost all cases) exit and requeue
before it was set. This lead to dupe mvms being created on multiple
hosts.

Closes https://github.com/weaveworks/cluster-api-provider-microvm/issues/111

feat: do not requeue after a create

Instead we can just switch on the state immediately (at that point it
will be the default `pending`) and update the cluster conditions before
requeueing.

feat: Return mvm object from service.Create

This returns the microvm in the Create response so that we can use
details for subsequent actions, eg status checks and getting the UUID.

Closes https://github.com/weaveworks/cluster-api-provider-microvm/issues/113