### PR TITLE
feat: default some template variables

### DIFF
--- a/templates/cluster-template-cilium.yaml
+++ b/templates/cluster-template-cilium.yaml
@@ -44,7 +44,7 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: "${KUBERNETES_VERSION}"
+  version: "${KUBERNETES_VERSION:=v1.21.8}"
   machineTemplate:
     infrastructureRef:
       kind: MicrovmMachineTemplate
@@ -76,11 +76,11 @@ spec:
       memoryMb: 2048
       rootVolume:
         id: root
-        image: ${MVM_ROOT_IMAGE}
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks/capmvm-kubernetes:${KUBERNETES_VERSION#v}}"
         mountPoint: "/"
       kernel:
         filename: "boot/vmlinux"
-        image: ${MVM_KERNEL_IMAGE}
+        image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks/flintlock-kernel:5.10.77}"
       kernelCmdline: {}
       networkInterfaces:
       - guestDeviceName: "eth1"
@@ -98,7 +98,7 @@ spec:
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"
-      version: "${KUBERNETES_VERSION}"
+      version: "${KUBERNETES_VERSION:=v1.21.8}"
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
@@ -120,11 +120,11 @@ spec:
       memoryMb: 2048
       rootVolume:
         id: root
-        image: ${MVM_ROOT_IMAGE}
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks/capmvm-kubernetes:${KUBERNETES_VERSION#v}}"
         mountPoint: "/"
       kernel:
         filename: "boot/vmlinux"
-        image: ${MVM_KERNEL_IMAGE}
+        image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks/flintlock-kernel:5.10.77}"
       kernelCmdline: {}
       networkInterfaces:
       - guestDeviceName: "eth1"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -40,7 +40,7 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: "${KUBERNETES_VERSION}"
+  version: "${KUBERNETES_VERSION:=v1.21.8}"
   machineTemplate:
     infrastructureRef:
       kind: MicrovmMachineTemplate
@@ -72,11 +72,11 @@ spec:
       memoryMb: 2048
       rootVolume:
         id: root
-        image: ${MVM_ROOT_IMAGE}
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks/capmvm-kubernetes:${KUBERNETES_VERSION#v}}"
         mountPoint: "/"
       kernel:
         filename: "boot/vmlinux"
-        image: ${MVM_KERNEL_IMAGE}
+        image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks/flintlock-kernel:5.10.77}"
       kernelCmdline: {}
       networkInterfaces:
       - guestDeviceName: "eth1"
@@ -94,7 +94,7 @@ spec:
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"
-      version: "${KUBERNETES_VERSION}"
+      version: "${KUBERNETES_VERSION:=v1.21.8}"
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
@@ -116,12 +116,12 @@ spec:
       memoryMb: 2048
       rootVolume:
         id: root
-        image: ${MVM_ROOT_IMAGE}
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks/capmvm-kubernetes:${KUBERNETES_VERSION#v}}"
         mountPoint: "/"
       kernel:
         filename: "boot/vmlinux"
-        image: ${MVM_KERNEL_IMAGE}
-      kernelCmdline: {}
+        image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks/flintlock-kernel:5.10.77}"
+      kernelCmdline: console=ttyS0 reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ds=nocloud-net;s=http://169.254.169.254/latest/
       networkInterfaces:
       - guestDeviceName: "eth1"
         type: "macvtap"


### PR DESCRIPTION
Some vars are just irritating to look up and set, this change means users don't have to set:

```
export KUBERNETES_VERSION=v1.21.8
export MVM_ROOT_IMAGE=ghcr.io/weaveworks/capmvm-kubernetes:1.21.8
export MVM_KERNEL_IMAGE=ghcr.io/weaveworks/flintlock-kernel:5.10.77
```

leaving them with just the ones they care about 