### PR TITLE
Revert "Use bot token for image push (#127)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.QUICK_SILVER_GHCR_BOT_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Build docker image
       run: make docker-build TAG=${{ env.TAG }}
     - name: Push docker image


### PR DESCRIPTION
This reverts commit e996e5fb6fb0c70a01160f041dbb99eda252e74b.

That token does not work and I want to do a release. So for now we are rolling back to use the old secret.