### PR TITLE
build: added write permissions for the release GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
       run: make docker-push TAG=${{ env.TAG }}
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build]
     steps:
     - name: Checkout
@@ -46,7 +48,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        prerelease: true
+        prerelease: false
         draft: true
         fail_on_unmatched_files: true
         generate_release_notes: true


### PR DESCRIPTION
**What this PR does / why we need it**:

With the change of the repo the default permissions for the GitHub token have changed. This gives the token write permissions for the release GHA as it needs to create a release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->
