### PR TITLE
feat: Add cluster opt for host client basic auth

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+    go: "1.17"
     timeout: 10m
     tests: false
     allow-parallel-runners: true
@@ -92,3 +93,4 @@ linters:
   - maligned
   - scopelint
   - tagliatelle
+  - wrapcheck

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ test: ## Run tests.
 
 ##@ Binaries
 
+.PHONY: build
+build: managers ## Build manager binary.
+
 .PHONY: managers
 managers: ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS} -extldflags '-static'" -o $(BIN_DIR)/manager .

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -149,6 +149,21 @@ type StaticPoolPlacement struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
 	Hosts []MicrovmHost `json:"hosts"`
+	// BasicAuthSecret is the name of the secret containing basic auth info for each
+	// host listed in Hosts.
+	// The secret should be created in the same namespace as the Cluster.
+	// The secret should contain a data entry for each host Endpoint without the port:
+	//
+	// apiVersion: v1
+	// kind: Secret
+	// metadata:
+	// 	name: mybasicauthsecret
+	//	namespace: same-as-cluster
+	// type: Opaque
+	// data:
+	// 	1.2.4.5: YWRtaW4=
+	// 	myhost: MWYyZDFlMmU2N2Rm
+	BasicAuthSecret string `json:"basicAuthSecret,omitempty"`
 }
 
 type MicrovmHost struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
@@ -89,6 +89,13 @@ spec:
                     description: StaticPool is used to specify that static pool placement
                       should be used.
                     properties:
+                      basicAuthSecret:
+                        description: "BasicAuthSecret is the name of the secret containing
+                          basic auth info for each host listed in Hosts. The secret
+                          should contain a data entry for each host Endpoint: \n apiVersion:
+                          v1 kind: Secret metadata: name: mybasicauthsecret type:
+                          Opaque data: 1.2.4.5: YWRtaW4= myhost: MWYyZDFlMmU2N2Rm"
+                        type: string
                       hosts:
                         description: Hosts defines the pool of hosts that should be
                           used when creating microvms. The hosts will be supplied

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/api/v1alpha1"
 	infrav1 "github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/api/v1alpha1"
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/controllers"
+	flclient "github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/client"
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/services/microvm"
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/services/microvm/mock_client"
 	flintlockv1 "github.com/weaveworks-liquidmetal/flintlock/api/services/microvm/v1alpha1"
@@ -88,7 +89,7 @@ func (co clusterObjects) AsRuntimeObjects() []runtime.Object {
 func reconcileMachine(client client.Client, mockAPIClient microvm.Client) (ctrl.Result, error) {
 	machineController := &controllers.MicrovmMachineReconciler{
 		Client: client,
-		MvmClientFunc: func(address string, proxy *infrav1.Proxy) (microvm.Client, error) {
+		MvmClientFunc: func(address string, opts ...flclient.Options) (microvm.Client, error) {
 			return mockAPIClient, nil
 		},
 	}

--- a/docs/development-with-tilt.md
+++ b/docs/development-with-tilt.md
@@ -45,7 +45,7 @@ In your cluster-api folder create a file called **tilt-settings.json**:
 ```json
 {
     "default_registry": "gcr.io/yourusername",
-    "provider_repos": ["../../github.com/weaveworks-liquidmetal/cluster-api-provider-microvm"],
+    "provider_repos": ["PATH/TO/YOUR/CAPMVM"],
     "enable_providers": ["microvm", "kubeadm-bootstrap", "kubeadm-control-plane"],
     "kustomize_substitutions": {
         "EXP_MACHINE_POOL": "true",
@@ -77,7 +77,11 @@ We will run tilt in a kind based cluster.
 3. Run the following:
 
     ```bash
-    kind create cluster && tilt up
+    # if you have any GITHUB_TOKEN or cred set in the environment, unset that first
+
+    export CAPI_KIND_CLUSTER_NAME=capmvm-test
+    kind create cluster --name $CAPI_KIND_CLUSTER_NAME
+    tilt up
     ```
 
 When tilt is started you can press the **spacebar** to open up a browser based UI.

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+)
+
+type basicAuth struct {
+	token string
+}
+
+// Basic creates a basicAuth with a token.
+func Basic(t string) basicAuth { //nolint: revive // this will not be used
+	return basicAuth{token: t}
+}
+
+// GetRequestMetadata fullfills the credentials.PerRPCCredentials interface,
+// adding the basic auth token to the request authorization header.
+func (b basicAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+	enc := base64.StdEncoding.EncodeToString([]byte(b.token))
+
+	return map[string]string{
+		"authorization": "Basic " + enc,
+	}, nil
+}
+
+// GetRequestMetadata fullfills the credentials.PerRPCCredentials interface.
+func (basicAuth) RequireTransportSecurity() bool {
+	// TODO: change this to true when we add TLS here is a fake issue to make the linter shut up #123
+	return false
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+
+	flintlockv1 "github.com/weaveworks-liquidmetal/flintlock/api/services/microvm/v1alpha1"
+	flgrpc "github.com/weaveworks-liquidmetal/flintlock/client/grpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	//+kubebuilder:scaffold:imports
+	infrav1 "github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/api/v1alpha1"
+	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/services/microvm"
+)
+
+type clientConfig struct {
+	basicAuthToken string
+	proxy          *infrav1.Proxy
+}
+
+// Options is a func to add a option to the flintlock host client.
+type Options func(*clientConfig)
+
+// WithBasicAuth adds a basic auth token to the client credentials.
+func WithBasicAuth(t string) Options {
+	return func(c *clientConfig) {
+		c.basicAuthToken = t
+	}
+}
+
+// WithProxy adds a proxy server to the client.
+func WithProxy(p *infrav1.Proxy) Options {
+	return func(c *clientConfig) {
+		c.proxy = p
+	}
+}
+
+// FactoryFunc is a func to create a new flintlock client.
+type FactoryFunc func(address string, opts ...Options) (microvm.Client, error)
+
+// NewFlintlockClient returns a connected client to a flintlock host.
+func NewFlintlockClient(address string, opts ...Options) (microvm.Client, error) {
+	cfg := buildConfig(opts...)
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	if cfg.basicAuthToken != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(Basic(cfg.basicAuthToken)))
+	}
+
+	if cfg.proxy != nil {
+		url, err := url.Parse(cfg.proxy.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("parsing proxy server url %s: %w", cfg.proxy.Endpoint, err)
+		}
+
+		dialOpts = append(dialOpts, flgrpc.WithProxy(url))
+	}
+
+	conn, err := grpc.Dial(address, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating grpc connection: %w", err)
+	}
+
+	flClient := flintlockv1.NewMicroVMClient(conn)
+
+	return flClient, nil
+}
+
+func buildConfig(opts ...Options) clientConfig {
+	cfg := clientConfig{}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}

--- a/internal/services/microvm/service.go
+++ b/internal/services/microvm/service.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/yaml.v2"
 	"k8s.io/utils/pointer"
 
-	infrav1 "github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/api/v1alpha1"
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/defaults"
 	"github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/internal/scope"
 )
@@ -25,8 +24,6 @@ import (
 const (
 	cloudInitHeader = "#cloud-config\n"
 )
-
-type ClientFactoryFunc func(address string, proxy *infrav1.Proxy) (Client, error)
 
 type Client interface {
 	flintlockv1.MicroVMClient


### PR DESCRIPTION
Part of https://github.com/weaveworks-liquidmetal/flintlock/issues/356

**User value:**

This commit will let users set the basic auth tokens for each flintlock
host.
To keep things simple, users will create a secret in the same namespace
as their cluster. The secret can be called whatever they like, and they
provide the name of this secret in the `MvmCluster.Spec`:

```
spec:
 placement:
   staticPool:
     basicAuthSecret: mybasicsecret
     hosts:
     - controlplaneAllowed: true
       endpoint: 192.168.0.31:9090
```

The option is under the `placement.staticPool`, since it will only be in
the non-dynamic placement that users will know the endpoint address
ahead of time. How auth is handled in the dynamic scheduling case is
coming soon.

The host endpoint is relevant because that is what the controller will
use to look up the associated auth token in the secret. Users will
provide a map of the auth info in the secret data:

```
apiVersion: v1
kind: Secret
metadata:
  name: mybasicsecret
  namespace: default
type: Opaque
data:
  192.168.0.31: Zm9v # foo, in this case
```

**Implementation:**

- In the secret example, note the absence of the `:` + port which would
  make the secret invalid.
  In the implementation, we remove the `:port` from the `endpoint`. To
  stop doing this, we could split the `endpoint` into `address` and
  `port`, and then gather those together for the `failureDomain`.
- I have refactored the flintlock client factory func to receive a
  variadic array of opts that we build into a config. This just makes it
  nicer to add more options to the client, without having to expand the
  signature.
- I have not done any TLS here deliberately to keep the change small.
- The client simply adds the token to the request authorization header.

**Testing:**
- I have manually tested using Tilt + a local flintlock.
- Unit testing is interesting, since there are not any outcomes that I
  can look for, since all the changes are on the client, which we use
  fakes for anyway. I will continue to think on it.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests