### PR TITLE
fix: Use Opaque secret for TLS config

### DIFF
--- a/api/v1alpha1/microvmcluster_types.go
+++ b/api/v1alpha1/microvmcluster_types.go
@@ -38,7 +38,7 @@ type MicrovmClusterSpec struct {
 	// TLSSecretRef is a reference to the name of a secret which contains TLS cert information
 	// for connecting to Flintlock hosts.
 	// The secret should be created in the same namespace as the MicroVMCluster.
-	// The secret should be of type kubernetes.io/tls https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
+	// The secret should be of type Opaque
 	// with the addition of a ca.crt key.
 	//
 	// apiVersion: v1
@@ -46,14 +46,20 @@ type MicrovmClusterSpec struct {
 	// metadata:
 	// 	name: secret-tls
 	// 	namespace: default  <- same as Cluster
-	// type: kubernetes.io/tls
+	// type: Opaque
 	// data:
 	// 	tls.crt: |
+	// 		-----BEGIN CERTIFICATE-----
 	// 		MIIC2DCCAcCgAwIBAgIBATANBgkqh ...
+	// 		-----END CERTIFICATE-----
 	// 	tls.key: |
+	// 		-----BEGIN EC PRIVATE KEY-----
 	// 		MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ ...
+	// 		-----END EC PRIVATE KEY-----
 	// 	ca.crt: |
+	// 		-----BEGIN CERTIFICATE-----
 	// 		MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ ...
+	// 		-----END CERTIFICATE-----
 	// +optional
 	TLSSecretRef string `json:"tlsSecretRef,omitempty"`
 }

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -187,7 +187,7 @@ type Proxy struct {
 
 // TLSConfig represents config for connecting to TLS enabled hosts.
 type TLSConfig struct {
-	Cert   string `json:"cert"`
-	Key    string `json:"key"`
-	CACert string `json:"caCert"`
+	Cert   []byte `json:"cert"`
+	Key    []byte `json:"key"`
+	CACert []byte `json:"caCert"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
@@ -154,12 +154,13 @@ spec:
                   to the name of a secret which contains TLS cert information for
                   connecting to Flintlock hosts. The secret should be created in the
                   same namespace as the MicroVMCluster. The secret should be of type
-                  kubernetes.io/tls https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
-                  with the addition of a ca.crt key. \n apiVersion: v1 kind: Secret
-                  metadata: name: secret-tls namespace: default  <- same as Cluster
-                  type: kubernetes.io/tls data: tls.crt: | MIIC2DCCAcCgAwIBAgIBATANBgkqh
-                  ... tls.key: | MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ ... ca.crt: | MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ
-                  ..."
+                  Opaque with the addition of a ca.crt key. \n apiVersion: v1 kind:
+                  Secret metadata: name: secret-tls namespace: default  <- same as
+                  Cluster type: Opaque data: tls.crt: | -----BEGIN CERTIFICATE-----
+                  MIIC2DCCAcCgAwIBAgIBATANBgkqh ... -----END CERTIFICATE----- tls.key:
+                  | -----BEGIN EC PRIVATE KEY----- MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ ...
+                  -----END EC PRIVATE KEY----- ca.crt: | -----BEGIN CERTIFICATE-----
+                  MIIEpgIBAAKCAQEA7yn3bRHQ5FHMQ ... -----END CERTIFICATE-----"
                 type: string
             required:
             - placement

--- a/controllers/microvmmachine_controller.go
+++ b/controllers/microvmmachine_controller.go
@@ -315,7 +315,7 @@ func (r *MicrovmMachineReconciler) getMicrovmService(
 
 	tls, err := machineScope.GetTLSConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting tls config: %w", err)
 	}
 
 	clientOpts := []flclient.Options{

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -6,12 +6,13 @@ import (
 )
 
 type basicAuth struct {
-	token string
+	token           string
+	requireSecurity bool
 }
 
 // Basic creates a basicAuth with a token.
-func Basic(t string) basicAuth { //nolint: revive // this will not be used
-	return basicAuth{token: t}
+func Basic(t string, s bool) basicAuth { //nolint: revive // this will not be used
+	return basicAuth{token: t, requireSecurity: s}
 }
 
 // GetRequestMetadata fullfills the credentials.PerRPCCredentials interface,
@@ -25,6 +26,6 @@ func (b basicAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[st
 }
 
 // GetRequestMetadata fullfills the credentials.PerRPCCredentials interface.
-func (basicAuth) RequireTransportSecurity() bool {
-	return true
+func (b basicAuth) RequireTransportSecurity() bool {
+	return b.requireSecurity
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -69,7 +69,11 @@ func NewFlintlockClient(address string, opts ...Options) (microvm.Client, error)
 	}
 
 	if cfg.basicAuthToken != "" {
-		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(Basic(cfg.basicAuthToken)))
+		dialOpts = append(dialOpts,
+			grpc.WithPerRPCCredentials(
+				Basic(cfg.basicAuthToken, cfg.tls != nil),
+			),
+		)
 	}
 
 	if cfg.proxy != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -102,13 +102,13 @@ func buildConfig(opts ...Options) clientConfig {
 }
 
 func loadTLS(cfg *infrav1.TLSConfig) (credentials.TransportCredentials, error) {
-	certificate, err := tls.LoadX509KeyPair(cfg.Cert, cfg.Key)
+	certificate, err := tls.X509KeyPair(cfg.Cert, cfg.Key)
 	if err != nil {
 		return nil, err
 	}
 
 	capool := x509.NewCertPool()
-	if !capool.AppendCertsFromPEM([]byte(cfg.CACert)) {
+	if !capool.AppendCertsFromPEM(cfg.CACert) {
 		return nil, fmt.Errorf("could not add cert to pool") //nolint: goerr113 // there is no err to wrap
 	}
 

--- a/internal/scope/machine_test.go
+++ b/internal/scope/machine_test.go
@@ -189,9 +189,9 @@ func TestMachineGetTLSConfig(t *testing.T) {
 	otherClusterNoTLS := newMicrovmCluster(clusterName)
 
 	tlsData := map[string][]byte{
-		"tls.crt": []byte("Zm9v"),
-		"tls.key": []byte("YmFy"),
-		"ca.crt":  []byte("YmF6"),
+		"tls.crt": []byte("foo"),
+		"tls.key": []byte("bar"),
+		"ca.crt":  []byte("baz"),
 	}
 	tlsSecret := newSecret(tlsSecretName, tlsData)
 
@@ -215,9 +215,9 @@ func TestMachineGetTLSConfig(t *testing.T) {
 			expected: func(cfg *v1alpha1.TLSConfig, err error) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg).ToNot(BeNil())
-				Expect(cfg.Cert).To(Equal("foo"))
-				Expect(cfg.Key).To(Equal("bar"))
-				Expect(cfg.CACert).To(Equal("baz"))
+				Expect(cfg.Cert).To(Equal([]byte("foo")))
+				Expect(cfg.Key).To(Equal([]byte("bar")))
+				Expect(cfg.CACert).To(Equal([]byte("baz")))
 			},
 		},
 		{


### PR DESCRIPTION
This is a collection of final fixes for TLS:

feat: Document that TLS secret is Opaque type

We realised that using a `tls` secret type and adding on a `ca.crt` key
would be annoying for users. With the `tls.crt` and `tls.key` fields,
users have the options to supply the values without the `START` and `END`
headers/footers, which are added back by the Secrets controller. For the
`ca.crt`, we would require that the headers are present (adding the pem
to the `CaPool` with fail otherwise) and we don't want to have to
process the bytes ourselves.
Users can create the other fields with or without headers, but one rule for
part of the data, and another rule for the rest is an irritating thing to
document so this just makes it easier.
Certmanager creates all data values with the headers present, so this
will work for either users in either case.

-------------------------------------

ref: Save TLS config data as bytes

Loading the TLS certs and CaPool takes `[]byte` anyway, so there is no
need to `string()` and `[]byte()` back and forth.

And load 509X from bytes not files.

Also stop decoding the secret data: I did not realised that was done
magically when you `Get` the secret.

Finally add a bit more logging to make TLS load failures clearer.

-----------------------------------

feat: RequireTransportSecurity when TLS is not nil

We only want to require this when TLS has actually been configured,
otherwise the client call will fail.


------------------------------------

Tested with Flintlock:

```
# in flintlock generate certs
./hack/scripts/gen_local_certs.sh all \
  --host 192.168.0.31 \
  --cfssl $(which cfssl) \
  --cfssljson $(which cfssljson) \
  --output tls-test

# start server
sudo ./bin/flintlockd run \
  --containerd-socket=/run/containerd-dev/containerd.sock \
  --parent-iface="${NET_DEVICE}" \
  --grpc-endpoint=0.0.0.0:9091 \
  --tls-cert tls-test/192.168.0.31.pem \
  --tls-key tls-test/192.168.0.31-key.pem \
  --tls-client-ca tls-test/intermediate-ca.pem \
  --tls-client-validate \
  --basic-auth-token foo

# in capi create cluster and start tilt
export CAPI_KIND_CLUSTER_NAME=capmvm-test
kind create cluster --name $CAPI_KIND_CLUSTER_NAME
tilt --host 0.0.0.0 up

# create secret with TLS config
kubectl create secret generic mytlssecret \
  --from-file=tls.crt=tls-test/liquidmetalclient1.pem \
  --from-file=tls.key=tls-test/liquidmetalclient1-key.pem \
  --from-file=ca.crt=tls-test/intermediate-ca.pem

# create secret with basic auth token
kubectl create secret generic foo --from-literal 192.168.0.31=foo

# generate a template with fields
cat cluster.yaml
...
spec:
  tlsSecretRef: mytlssecret
  placement:
    staticPool:
      basicAuthSecret: mybasicsecret
      hosts:
      - controlplaneAllowed: true
        endpoint: 192.168.0.31:9091
...

# and create
kubectl apply -f cluster.yaml
```