### PR TITLE
fix: explicitly close grpc client connection

### DIFF
--- a/controllers/microvmmachine_controller.go
+++ b/controllers/microvmmachine_controller.go
@@ -256,6 +256,8 @@ func (r *MicrovmMachineReconciler) reconcileNormal(
 		return ctrl.Result{}, err
 	}
 
+	defer mvmSvc.Dispose()
+
 	var microvm *flintlocktypes.MicroVM
 
 	providerID := machineScope.GetProviderID()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -90,9 +90,10 @@ func NewFlintlockClient(address string, opts ...Options) (microvm.Client, error)
 		return nil, fmt.Errorf("creating grpc connection: %w", err)
 	}
 
-	flClient := flintlockv1.NewMicroVMClient(conn)
-
-	return flClient, nil
+	return &disposableClient{
+		flintlockClient: flintlockv1.NewMicroVMClient(conn),
+		conn:            conn,
+	}, nil
 }
 
 func buildConfig(opts ...Options) clientConfig {

--- a/internal/client/disposable.go
+++ b/internal/client/disposable.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"context"
+
+	flintlockv1 "github.com/weaveworks-liquidmetal/flintlock/api/services/microvm/v1alpha1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type disposableClient struct {
+	flintlockClient flintlockv1.MicroVMClient
+	conn            *grpc.ClientConn
+}
+
+func (c *disposableClient) Dispose() {
+	if c.conn != nil {
+		c.conn.Close()
+	}
+}
+
+func (c *disposableClient) CreateMicroVM(ctx context.Context, in *flintlockv1.CreateMicroVMRequest, opts ...grpc.CallOption) (*flintlockv1.CreateMicroVMResponse, error) { //nolint:lll // it would make it less readable
+	return c.flintlockClient.CreateMicroVM(ctx, in, opts...)
+}
+
+func (c *disposableClient) DeleteMicroVM(ctx context.Context, in *flintlockv1.DeleteMicroVMRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) { //nolint:lll // it would make it less readable
+	return c.flintlockClient.DeleteMicroVM(ctx, in, opts...)
+}
+
+func (c *disposableClient) GetMicroVM(ctx context.Context, in *flintlockv1.GetMicroVMRequest, opts ...grpc.CallOption) (*flintlockv1.GetMicroVMResponse, error) { //nolint:lll // it would make it less readable
+	return c.flintlockClient.GetMicroVM(ctx, in, opts...)
+}
+
+func (c *disposableClient) ListMicroVMs(ctx context.Context, in *flintlockv1.ListMicroVMsRequest, opts ...grpc.CallOption) (*flintlockv1.ListMicroVMsResponse, error) { //nolint:lll // it would make it less readable
+	return c.flintlockClient.ListMicroVMs(ctx, in, opts...)
+}
+
+func (c *disposableClient) ListMicroVMsStream(ctx context.Context, in *flintlockv1.ListMicroVMsRequest, opts ...grpc.CallOption) (flintlockv1.MicroVM_ListMicroVMsStreamClient, error) { //nolint:lll // it would make it less readable
+	return c.flintlockClient.ListMicroVMsStream(ctx, in, opts...)
+}

--- a/internal/services/microvm/mock_client/fake_client.go
+++ b/internal/services/microvm/mock_client/fake_client.go
@@ -42,6 +42,10 @@ type FakeClient struct {
 		result1 *emptypb.Empty
 		result2 error
 	}
+	DisposeStub        func()
+	disposeMutex       sync.RWMutex
+	disposeArgsForCall []struct {
+	}
 	GetMicroVMStub        func(context.Context, *v1alpha1.GetMicroVMRequest, ...grpc.CallOption) (*v1alpha1.GetMicroVMResponse, error)
 	getMicroVMMutex       sync.RWMutex
 	getMicroVMArgsForCall []struct {
@@ -221,6 +225,30 @@ func (fake *FakeClient) DeleteMicroVMReturnsOnCall(i int, result1 *emptypb.Empty
 		result1 *emptypb.Empty
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClient) Dispose() {
+	fake.disposeMutex.Lock()
+	fake.disposeArgsForCall = append(fake.disposeArgsForCall, struct {
+	}{})
+	stub := fake.DisposeStub
+	fake.recordInvocation("Dispose", []interface{}{})
+	fake.disposeMutex.Unlock()
+	if stub != nil {
+		fake.DisposeStub()
+	}
+}
+
+func (fake *FakeClient) DisposeCallCount() int {
+	fake.disposeMutex.RLock()
+	defer fake.disposeMutex.RUnlock()
+	return len(fake.disposeArgsForCall)
+}
+
+func (fake *FakeClient) DisposeCalls(stub func()) {
+	fake.disposeMutex.Lock()
+	defer fake.disposeMutex.Unlock()
+	fake.DisposeStub = stub
 }
 
 func (fake *FakeClient) GetMicroVM(arg1 context.Context, arg2 *v1alpha1.GetMicroVMRequest, arg3 ...grpc.CallOption) (*v1alpha1.GetMicroVMResponse, error) {
@@ -428,6 +456,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createMicroVMMutex.RUnlock()
 	fake.deleteMicroVMMutex.RLock()
 	defer fake.deleteMicroVMMutex.RUnlock()
+	fake.disposeMutex.RLock()
+	defer fake.disposeMutex.RUnlock()
 	fake.getMicroVMMutex.RLock()
 	defer fake.getMicroVMMutex.RUnlock()
 	fake.listMicroVMsMutex.RLock()

--- a/internal/services/microvm/service.go
+++ b/internal/services/microvm/service.go
@@ -27,6 +27,7 @@ const (
 
 type Client interface {
 	flintlockv1.MicroVMClient
+	Dispose()
 }
 
 type Service struct {
@@ -111,6 +112,10 @@ func (s *Service) Delete(ctx context.Context) (*emptypb.Empty, error) {
 	}
 
 	return s.client.DeleteMicroVM(ctx, input)
+}
+
+func (s *Service) Dispose() {
+	s.client.Dispose()
 }
 
 func (s *Service) addMetadata(apiMicroVM *flintlocktypes.MicroVMSpec) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

When calling flintlock we where not explicitly closing the client
connection to the grpc server. As a result a goroutine is kept alive for
each client request and the number continue to rise until the server
can't accept any more requests.

This change will explicitly call `Close` for the underlying grpc client
connection which helps to ensure server side resource usage is kept to a
minimum.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates https://github.com/weaveworks-liquidmetal/flintlock/issues/503

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
