### PR TITLE
feat: Add short options for kernel and os versions

### DIFF
--- a/api/v1alpha1/microvmmachine_webhook.go
+++ b/api/v1alpha1/microvmmachine_webhook.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,7 +35,15 @@ var (
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *MicrovmMachine) ValidateCreate() error {
-	return nil
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, r.Spec.MicrovmSpec.Validate()...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1alpha1/validate.go
+++ b/api/v1alpha1/validate.go
@@ -18,3 +18,33 @@ func (p *Placement) Validate() []*field.Error {
 
 	return errs
 }
+
+func (s *MicrovmMachineSpec) Validate() []*field.Error {
+	var errs field.ErrorList
+
+	if s.VMSpec.OsVersion == "" {
+		if s.RootVolume.ID == "" {
+			errs = append(errs,
+				field.Required(field.NewPath("spec", "rootVolume", "id"), "must be set if osVersion is omitted"))
+		}
+
+		if s.RootVolume.Image == "" {
+			errs = append(errs,
+				field.Required(field.NewPath("spec", "rootVolume", "image"), "must be set if osVersion is omitted"))
+		}
+	}
+
+	if s.VMSpec.KernelVersion == "" {
+		if s.Kernel.Image == "" {
+			errs = append(errs,
+				field.Required(field.NewPath("spec", "kernel", "image"), "must be set if kernelVersion is omitted"))
+		}
+
+		if s.Kernel.Filename == "" {
+			errs = append(errs,
+				field.Required(field.NewPath("spec", "kernel", "filename"), "must be set if kernelVersion is omitted"))
+		}
+	}
+
+	return errs
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
@@ -191,10 +191,8 @@ spec:
                   type: object
                 type: array
             required:
-            - kernel
             - memoryMb
             - networkInterfaces
-            - rootVolume
             - vcpu
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
@@ -233,10 +233,8 @@ spec:
                           type: object
                         type: array
                     required:
-                    - kernel
                     - memoryMb
                     - networkInterfaces
-                    - rootVolume
                     - vcpu
                     type: object
                 required:

--- a/templates/cluster-template-cilium.yaml
+++ b/templates/cluster-template-cilium.yaml
@@ -72,11 +72,13 @@ metadata:
 spec:
   template:
     spec:
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       vcpu: 2
       memoryMb: 2048
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: "boot/vmlinux"
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"
@@ -119,11 +121,13 @@ metadata:
 spec:
   template:
     spec:
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       vcpu: 2
       memoryMb: 2048
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: "boot/vmlinux"
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"

--- a/templates/cluster-template-flannel.yaml
+++ b/templates/cluster-template-flannel.yaml
@@ -74,9 +74,11 @@ metadata:
 spec:
   template:
     spec:
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: boot/vmlinux
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"
@@ -121,9 +123,11 @@ metadata:
 spec:
   template:
     spec:
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: boot/vmlinux
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -70,9 +70,11 @@ spec:
     spec:
       vcpu: 2
       memoryMb: 2048
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: "boot/vmlinux"
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"
@@ -117,9 +119,11 @@ spec:
     spec:
       vcpu: 2
       memoryMb: 2048
+      kernelVersion: "${KERNEL_VERSION}"
+      osVersion: "${OS_VERSION}"
       rootVolume:
         id: root
-        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
+        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-k8s-os:1.23.5}"
       kernel:
         filename: "boot/vmlinux"
         image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"


### PR DESCRIPTION
This change makes it easier/lazier for people to configure their kernel
and os images. If users do not care about the specifics, and do not need
to bring custom images, they can simply set the following:

In the manifest:

```yaml
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: MicrovmMachineTemplate
spec:
  template:
    spec:
      kernelVersion: "${KERNEL_VERSION}"
      osVersion: "${OS_VERSION}"
      ...
```

Via the command line:

```bash
export KERNEL_VERSION=5.10.77
export OS_VERSION="${KUBERNETES_VERSION#*v}" # they already set this anyway
```

And we work out the rest. Long form, this is:

```yaml
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: MicrovmMachineTemplate
spec:
  template:
    spec:
      rootVolume:
        id: root
        image: "${MVM_ROOT_IMAGE:=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.23.5}"
      kernel:
        filename: "boot/vmlinux"
        image: "${MVM_KERNEL_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77}"
      additionalVolumes:
      - id: modules
        image: "${MVM_KERNEL_MODULES_IMAGE:=ghcr.io/weaveworks-liquidmetal/kernel-modules:5.10.77}"
        mountPoint: /lib/modules
```

Or via env vars:

```bash
export MVM_ROOT_IMAGE=docker.io/richardcase/ubuntu-bionic-test:cloudimage_v0.0.1
export MVM_KERNEL_IMAGE=docker.io/richardcase/ubuntu-bionic-kernel:0.0.11
export MVM_KERNEL_MODULES_IMAGE=ghcr.io/weaveworks-liquidmetal/kernel-modules:5.10.77
```

The previously existing fields will continue to exist and can be used if desired.

If both the short form options and the long-form fields are set, the
short-form values are what will be used. (Or I can make it the long-form
whichever people prefer.)


The previously required kernel and root volume fields are now optional so, the machine webhook has been updated to ensure that at least one of the options are provided. 

Part of https://github.com/weaveworks-liquidmetal/image-builder/issues/49

Depends on https://github.com/weaveworks-liquidmetal/controller-pkg/pull/3 and https://github.com/weaveworks-liquidmetal/controller-pkg/pull/2 requiring a mod bump here after those 2 are merged.