### PR TITLE
fix: Remove `creationTimestamp` from CRD bases

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmclusters.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: microvmclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachines.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: microvmmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_microvmmachinetemplates.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: microvmmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -51,7 +50,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
Removing these lines fixes the Liquid Metal Acceptance Tests suite.

```
[BeforeSuite] PASSED [54.118 seconds]
------------------------------
CAPMVM should create cluster with single control plane node and 5 worker nodes
/root/cluster-api-provider-microvm/test/e2e/e2e_test.go:49
  INFO: Creating namespace simple-cluster-hdiaut
  INFO: Creating event watcher for namespace "simple-cluster-hdiaut"
  STEP: Creating microvm cluster @ 03/17/23 13:43:43.876
  STEP: Setting environment variable: key=CONTROL_PLANE_VIP, value=192.168.1.25 @ 03/17/23 13:43:43.876
  STEP: Setting environment variable: key=KUBERNETES_VERSION, value=v1.21.8 @ 03/17/23 13:43:43.876
  STEP: Setting environment variable: key=MVM_ROOT_IMAGE, value=ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:1.21.8 @ 03/17/23 13:43:43.876
  STEP: Getting the cluster template yaml @ 03/17/23 13:43:43.876
  INFO: clusterctl config cluster simple-cluster-9kl68c --infrastructure microvm:v0.6.99 --kubernetes-version v1.21.8 --control-plane-machine-count 1 --worker-machine-count 5 --flavor cilium
  STEP: Adding provided flintlock hosts to MicrovmCluster template @ 03/17/23 13:43:43.93
  STEP: Applying the cluster template yaml to the cluster @ 03/17/23 13:43:43.933
cluster.cluster.x-k8s.io/simple-cluster-9kl68c created
microvmcluster.infrastructure.cluster.x-k8s.io/simple-cluster-9kl68c created
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/simple-cluster-9kl68c-control-plane created
microvmmachinetemplate.infrastructure.cluster.x-k8s.io/simple-cluster-9kl68c-control-plane created
machinedeployment.cluster.x-k8s.io/simple-cluster-9kl68c-md-0 created
microvmmachinetemplate.infrastructure.cluster.x-k8s.io/simple-cluster-9kl68c-md-0 created
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/simple-cluster-9kl68c-md-0 created
clusterresourceset.addons.cluster.x-k8s.io/crs-cilium created
configmap/cilium-addon created

  STEP: Waiting for the top level cluster object to register as provisioned @ 03/17/23 13:43:44.679
  STEP: Waiting for cluster to enter the provisioned phase @ 03/17/23 13:43:44.686
  STEP: Waiting for control plane to be initialized @ 03/17/23 13:43:54.695
  INFO: Waiting for the first control plane machine managed by simple-cluster-hdiaut/simple-cluster-9kl68c-control-plane to be provisioned
  STEP: Waiting for one control plane node to exist @ 03/17/23 13:43:54.71
  STEP: Waiting for control plane to be ready @ 03/17/23 13:44:54.777
  INFO: Waiting for control plane simple-cluster-hdiaut/simple-cluster-9kl68c-control-plane to be ready (implies underlying nodes to be ready as well)
  STEP: Waiting for the control plane to be ready @ 03/17/23 13:44:54.785
  STEP: Checking all the control plane machines are in the expected failure domains @ 03/17/23 13:45:24.802
  STEP: Waiting for the machine deployments to be provisioned @ 03/17/23 13:45:24.816
  STEP: Waiting for the workload nodes to exist @ 03/17/23 13:45:24.83
  STEP: Checking all the machines controlled by simple-cluster-9kl68c-md-0 are in the "<None>" failure domain @ 03/17/23 13:45:54.909
  STEP: Checking that microvms are allocated across all given flintlock hosts @ 03/17/23 13:45:54.934
  STEP: Checking that an application can be deployed to the workload cluster @ 03/17/23 13:45:54.952
  STEP: PASSED! @ 03/17/23 13:46:55.02
  STEP: Deleting cluster simple-cluster-9kl68c @ 03/17/23 13:46:55.035
  INFO: Waiting for the Cluster simple-cluster-hdiaut/simple-cluster-9kl68c to be deleted
  STEP: Waiting for cluster simple-cluster-9kl68c to be deleted @ 03/17/23 13:46:55.04
• [261.251 seconds]
------------------------------
[AfterSuite]
/root/cluster-api-provider-microvm/test/e2e/e2e_suite_test.go:32
[AfterSuite] PASSED [1.155 seconds]
------------------------------

Ran 1 of 1 Specs in 316.525 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 5m18.421479152s
Test Suite Passed
```

Closes https://github.com/weaveworks-liquidmetal/cluster-api-provider-microvm/issues/266 (you can find full context for the fix there)