### PR TITLE
Fix: the sed that help to build the 'infrastructure-components.yaml'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,8 @@ jobs:
     - name: Update manifests
       run: |
         # this is quite naive, but i don't think we need more for now
-        sed -i "s/dev/${TAG}/g" config/default/manager_image_patch.yaml
+        # there is a bug here as the previous sed replace the "dev" pattern in the tag and in the org name, somthing with capturing group seems better
+        sed -r "/image:/ s/^(.*):(.*)$/\1:${TAG}/g" config/default/manager_image_patch.yaml
         kustomize build config/default/ > infrastructure-components.yaml
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   template:
     spec:
-      imagePullSecrets:
-      - name: capmvm-private-image-cred
       containers:
       - image: ghcr.io/liquidmetal-dev/cluster-api-provider-microvm:dev
         name: manager


### PR DESCRIPTION
1. The actual sed replace the 'dev' pattern in 2 places in the manager_image_patch.yaml :
- The image is replaced (that's good)
- The 'dev' suffix of the 'liquidmetal-dev' org name is also replaced, and kubelet/containerd try to pull the ghcr.io/liquidmetal-v0.10.1/cluster-api-provider-microvm:v0.10.1  (that's not good :))

2. The imagePullSecrets is no longer needed.


Using capturing group on matching line could fix the bug

kind/bug

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Actually, using clusterctl to bootstrap a cluster with CAPI doesn't work, this PR seems to fix it.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests